### PR TITLE
Refactor the API and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ Since RxJS is ever-changing, this removes the need to maintain a list, instead g
 #### webpack.config.js
 
 ```js
-import createRxJSExternals from 'webpack-rxjs-externals';
+import webpackRxjsExternals from 'webpack-rxjs-externals';
 
 export default {
-  externals: {
-    ...createRxJSExternals(),
+  externals: [
+    webpackRxjsExternals(),
     // other externals here
-  }
+  ]
 };
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # webpack-rxjs-externals
 
-Utility to generate all the ["externals"](https://webpack.github.io/docs/library-and-externals.html) for your webpack config.
+Utility to generate all the ["externals"](https://webpack.js.org/configuration/externals/#externals) for your webpack config.
 
 Since RxJS is ever-changing, this removes the need to maintain a list, instead generating it on the fly.
 

--- a/package.json
+++ b/package.json
@@ -17,12 +17,6 @@
     "url": "git+https://github.com/jayphelps/webpack-rxjs-externals.git"
   },
   "license": "MIT",
-  "peerDependencies": {
-    "rxjs": "^5.0.0"
-  },
-  "dependencies": {
-    "glob": "7.0.5"
-  },
   "devDependencies": {
     "chai": "^3.5.0",
     "memory-fs": "^0.4.1",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,13 @@
   "version": "0.0.4",
   "description": "Generate webpack externals for RxJS v5",
   "main": "index.js",
+  "files": [
+    "index.js"
+  ],
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha test/index.spec.js",
+    "test:watch": "npm t -- --watch",
+    "start": "npm run test:watch"
   },
   "author": "Jay Phelps <hello@jayphelps.com>",
   "repository": {
@@ -13,12 +18,16 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "rxjs": "^5.0.0-beta.9"
+    "rxjs": "^5.0.0"
   },
   "dependencies": {
     "glob": "7.0.5"
   },
   "devDependencies": {
-    "rxjs": "^5.0.0-beta.9"
+    "chai": "^3.5.0",
+    "memory-fs": "^0.4.1",
+    "mocha": "^3.2.0",
+    "rxjs": "^5.1.0",
+    "webpack": "^2.2.1"
   }
 }

--- a/test/fixtures/observable-method/expected/index.js
+++ b/test/fixtures/observable-method/expected/index.js
@@ -1,0 +1,97 @@
+(function webpackUniversalModuleDefinition(root, factory) {
+	if(typeof exports === 'object' && typeof module === 'object')
+		module.exports = factory(require("rxjs/observable/interval"));
+	else if(typeof define === 'function' && define.amd)
+		define(["rxjs/observable/interval"], factory);
+	else if(typeof exports === 'object')
+		exports["rxjsTest"] = factory(require("rxjs/observable/interval"));
+	else
+		root["rxjsTest"] = factory(root["Rx"]["Observable"]);
+})(this, function(__WEBPACK_EXTERNAL_MODULE_0__) {
+return /******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// identity function for calling harmony imports with the correct context
+/******/ 	__webpack_require__.i = function(value) { return value; };
+
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 1);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ (function(module, exports) {
+
+module.exports = __WEBPACK_EXTERNAL_MODULE_0__;
+
+/***/ }),
+/* 1 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_rxjs_observable_interval__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_rxjs_observable_interval___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_rxjs_observable_interval__);
+
+
+/***/ })
+/******/ ]);
+});

--- a/test/fixtures/observable-method/index.js
+++ b/test/fixtures/observable-method/index.js
@@ -1,0 +1,1 @@
+import interval from 'rxjs/observable/interval';

--- a/test/fixtures/observable-type/expected/index.js
+++ b/test/fixtures/observable-type/expected/index.js
@@ -1,0 +1,97 @@
+(function webpackUniversalModuleDefinition(root, factory) {
+	if(typeof exports === 'object' && typeof module === 'object')
+		module.exports = factory(require("rxjs/observable/ArrayLikeObservable"));
+	else if(typeof define === 'function' && define.amd)
+		define(["rxjs/observable/ArrayLikeObservable"], factory);
+	else if(typeof exports === 'object')
+		exports["rxjsTest"] = factory(require("rxjs/observable/ArrayLikeObservable"));
+	else
+		root["rxjsTest"] = factory(root["Rx"]);
+})(this, function(__WEBPACK_EXTERNAL_MODULE_0__) {
+return /******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// identity function for calling harmony imports with the correct context
+/******/ 	__webpack_require__.i = function(value) { return value; };
+
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 1);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ (function(module, exports) {
+
+module.exports = __WEBPACK_EXTERNAL_MODULE_0__;
+
+/***/ }),
+/* 1 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_rxjs_observable_ArrayLikeObservable__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_rxjs_observable_ArrayLikeObservable___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_rxjs_observable_ArrayLikeObservable__);
+
+
+/***/ })
+/******/ ]);
+});

--- a/test/fixtures/observable-type/index.js
+++ b/test/fixtures/observable-type/index.js
@@ -1,0 +1,1 @@
+import ArrayLikeObservable from 'rxjs/observable/ArrayLikeObservable';

--- a/test/fixtures/operator/expected/index.js
+++ b/test/fixtures/operator/expected/index.js
@@ -1,0 +1,97 @@
+(function webpackUniversalModuleDefinition(root, factory) {
+	if(typeof exports === 'object' && typeof module === 'object')
+		module.exports = factory(require("rxjs/operator/map"));
+	else if(typeof define === 'function' && define.amd)
+		define(["rxjs/operator/map"], factory);
+	else if(typeof exports === 'object')
+		exports["rxjsTest"] = factory(require("rxjs/operator/map"));
+	else
+		root["rxjsTest"] = factory(root["Rx"]["Observable"]["prototype"]);
+})(this, function(__WEBPACK_EXTERNAL_MODULE_0__) {
+return /******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// identity function for calling harmony imports with the correct context
+/******/ 	__webpack_require__.i = function(value) { return value; };
+
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 1);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ (function(module, exports) {
+
+module.exports = __WEBPACK_EXTERNAL_MODULE_0__;
+
+/***/ }),
+/* 1 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_rxjs_operator_map__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_rxjs_operator_map___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_rxjs_operator_map__);
+
+
+/***/ })
+/******/ ]);
+});

--- a/test/fixtures/operator/index.js
+++ b/test/fixtures/operator/index.js
@@ -1,0 +1,1 @@
+import map from 'rxjs/operator/map';

--- a/test/fixtures/scheduler-method/expected/index.js
+++ b/test/fixtures/scheduler-method/expected/index.js
@@ -1,0 +1,97 @@
+(function webpackUniversalModuleDefinition(root, factory) {
+	if(typeof exports === 'object' && typeof module === 'object')
+		module.exports = factory(require("rxjs/scheduler/asap"));
+	else if(typeof define === 'function' && define.amd)
+		define(["rxjs/scheduler/asap"], factory);
+	else if(typeof exports === 'object')
+		exports["rxjsTest"] = factory(require("rxjs/scheduler/asap"));
+	else
+		root["rxjsTest"] = factory(root["Rx"]["Scheduler"]);
+})(this, function(__WEBPACK_EXTERNAL_MODULE_0__) {
+return /******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// identity function for calling harmony imports with the correct context
+/******/ 	__webpack_require__.i = function(value) { return value; };
+
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 1);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ (function(module, exports) {
+
+module.exports = __WEBPACK_EXTERNAL_MODULE_0__;
+
+/***/ }),
+/* 1 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_rxjs_scheduler_asap__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_rxjs_scheduler_asap___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_rxjs_scheduler_asap__);
+
+
+/***/ })
+/******/ ]);
+});

--- a/test/fixtures/scheduler-method/index.js
+++ b/test/fixtures/scheduler-method/index.js
@@ -1,0 +1,1 @@
+import asap from 'rxjs/scheduler/asap';

--- a/test/fixtures/scheduler-type/expected/index.js
+++ b/test/fixtures/scheduler-type/expected/index.js
@@ -1,0 +1,97 @@
+(function webpackUniversalModuleDefinition(root, factory) {
+	if(typeof exports === 'object' && typeof module === 'object')
+		module.exports = factory(require("rxjs/scheduler/VirtualTimeScheduler"));
+	else if(typeof define === 'function' && define.amd)
+		define(["rxjs/scheduler/VirtualTimeScheduler"], factory);
+	else if(typeof exports === 'object')
+		exports["rxjsTest"] = factory(require("rxjs/scheduler/VirtualTimeScheduler"));
+	else
+		root["rxjsTest"] = factory(root["Rx"]);
+})(this, function(__WEBPACK_EXTERNAL_MODULE_0__) {
+return /******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// identity function for calling harmony imports with the correct context
+/******/ 	__webpack_require__.i = function(value) { return value; };
+
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 1);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ (function(module, exports) {
+
+module.exports = __WEBPACK_EXTERNAL_MODULE_0__;
+
+/***/ }),
+/* 1 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_rxjs_scheduler_VirtualTimeScheduler__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_rxjs_scheduler_VirtualTimeScheduler___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_rxjs_scheduler_VirtualTimeScheduler__);
+
+
+/***/ })
+/******/ ]);
+});

--- a/test/fixtures/scheduler-type/index.js
+++ b/test/fixtures/scheduler-type/index.js
@@ -1,0 +1,1 @@
+import VirtualTimeScheduler from 'rxjs/scheduler/VirtualTimeScheduler';

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,0 +1,58 @@
+const fs = require('fs');
+const path = require('path');
+const webpack = require('webpack');
+const MemoryFileSystem = require('memory-fs');
+const { expect } = require('chai');
+const webpackRxjsExternals = require('../index');
+
+const fixturesDir = 'fixtures';
+const fixtures = fs.readdirSync(path.join(__dirname, fixturesDir));
+
+describe('webpack-rxjs-externals', () => {
+
+  it('should mark rxjs imports as external', () => {
+
+    const promises = fixtures.map(fixture => {
+
+      return new Promise((resolve, reject) => {
+
+        try {
+
+          const config = {
+            entry: path.join(__dirname, fixturesDir, fixture, 'index.js'),
+            output: {
+              filename: 'index.js',
+              path: __dirname,
+              libraryTarget: 'umd',
+              library: 'rxjsTest'
+            },
+            externals: webpackRxjsExternals()
+          };
+
+          const expectedOutput = fs.readFileSync(path.join(__dirname, fixturesDir, fixture, 'expected', 'index.js')).toString();
+
+          const compiler = webpack(config);
+          compiler.outputFileSystem = new MemoryFileSystem();
+
+          compiler.run((err, stats) => {
+            if (err) {
+              reject(err);
+            }
+            const actualOutput = stats.compilation.assets['index.js'].source();
+            expect(actualOutput).to.equal(expectedOutput);
+            resolve();
+          });
+
+        } catch (err) {
+          reject(err);
+        }
+
+      });
+
+    });
+
+    return Promise.all(promises);
+
+  });
+
+});

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const webpack = require('webpack');
 const MemoryFileSystem = require('memory-fs');
-const { expect } = require('chai');
+const expect = require('chai').expect;
 const webpackRxjsExternals = require('../index');
 
 const fixturesDir = 'fixtures';


### PR DESCRIPTION
I started to write my own version of this, then realised the package already existed so figured I may as well send you a PR rather than creating an almost identical module. 

There's a small API breaking change where the library needs to be used in an externals array instead of an object, but this allows for a cleaner approach without having to use glob to read all the rxjs imports. Also node >= 4 is required now as 0.10 and 0.12 are no longer supported.

LMK if you'd like me to change anything 😃 