### PR TITLE
Lettable operators

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
 const rootPatterns = [{
-  // rxjs/operator/map
-  regex: /^rxjs\/operator\//,
-  root: ['Rx', 'Observable', 'prototype']
-}, {
   // rxjs/operators/map
   regex: /^rxjs\/operators\//,
   root: ['Rx', 'operators']
+}, {
+  // rxjs/operator/map
+  regex: /^rxjs\/operator\//,
+  root: ['Rx', 'Observable', 'prototype']
 }, {
   // rxjs/observable/interval
   regex: /^rxjs\/observable\/[a-z]/,

--- a/index.js
+++ b/index.js
@@ -3,6 +3,10 @@ const rootPatterns = [{
   regex: /^rxjs\/operator\//,
   root: ['Rx', 'Observable', 'prototype']
 }, {
+  // rxjs/operators/map
+  regex: /^rxjs\/operators\//,
+  root: ['Rx', 'operators']
+}, {
   // rxjs/observable/interval
   regex: /^rxjs\/observable\/[a-z]/,
   root: ['Rx', 'Observable']


### PR DESCRIPTION
Since RxJS [v5.5](https://github.com/ReactiveX/rxjs/blob/master/CHANGELOG.md#550-2017-10-18) is out of beta, lettable operators are now added to externals.

We need it in https://frint.js.org

Further reading: https://github.com/ReactiveX/rxjs/blob/master/doc/lettable-operators.md