### PR TITLE
Lettable operators with destructuring

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,10 @@ const rootPatterns = [{
   regex: /^rxjs\/operators\//,
   root: ['Rx', 'operators']
 }, {
+  // rxjs/operators
+  regex: /^rxjs\/operators/,
+  root: ['Rx', 'operators']
+}, {
   // rxjs/operator/map
   regex: /^rxjs\/operator\//,
   root: ['Rx', 'Observable', 'prototype']


### PR DESCRIPTION
Previously in #5, we added externals for imports like:

```js
import { map } from 'rxjs/operators/map';
import { filter } from 'rxjs/operators/filter';
```

This PR now additionally externalizes multiple imports from `rxjs/operators` directly:

```js
import { map, filter } from 'rxjs/operators';
```