### PR TITLE
fix(let): Handle let/letProto differences.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,22 @@ export default {
   ]
 };
 ```
+
+If the `let` operator is used, an alias needs to be configured, as the exported name (`letProto`) differs from the prototype name (`let`):
+
+```js
+import webpackRxjsExternals from 'webpack-rxjs-externals';
+
+export default {
+  externals: [
+    webpackRxjsExternals(),
+    // other externals here
+  ],
+  resolve: {
+    alias: {
+      ...webpackRxjsExternals.alias(),
+      // other aliases here
+    }
+  }
+};
+```

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ function rxjsExternalsFactory() {
 
   return function rxjsExternals(context, request, callback) {
 
-    if (request.startsWith('rxjs/')) {
+    if (request.startsWith('rxjs/') && !/rxjs\/operator\/let/.test(request)) {
       return callback(null, {
         root: rootForRequest(request),
         commonjs: request,
@@ -56,5 +56,14 @@ function rxjsExternalsFactory() {
   };
 
 }
+
+rxjsExternalsFactory.alias = function () {
+
+  const path = require('path');
+
+  return {
+    'rxjs/operator/let$': path.resolve(__dirname, 'let')
+  };
+};
 
 module.exports = rxjsExternalsFactory;

--- a/let.js
+++ b/let.js
@@ -1,0 +1,2 @@
+const { Observable } = require('rxjs/Observable');
+exports.letProto = Observable.prototype.let;

--- a/test/fixtures/operator-let/expected/index.js
+++ b/test/fixtures/operator-let/expected/index.js
@@ -1,0 +1,104 @@
+(function webpackUniversalModuleDefinition(root, factory) {
+	if(typeof exports === 'object' && typeof module === 'object')
+		module.exports = factory(require("rxjs/Observable"));
+	else if(typeof define === 'function' && define.amd)
+		define(["rxjs/Observable"], factory);
+	else if(typeof exports === 'object')
+		exports["rxjsTest"] = factory(require("rxjs/Observable"));
+	else
+		root["rxjsTest"] = factory(root["Rx"]);
+})(this, function(__WEBPACK_EXTERNAL_MODULE_2__) {
+return /******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// identity function for calling harmony imports with the correct context
+/******/ 	__webpack_require__.i = function(value) { return value; };
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 1);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ (function(module, exports, __webpack_require__) {
+
+const { Observable } = __webpack_require__(2);
+exports.letProto = Observable.prototype.let;
+
+/***/ }),
+/* 1 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_rxjs_operator_let__ = __webpack_require__(0);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_rxjs_operator_let___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_rxjs_operator_let__);
+
+
+/***/ }),
+/* 2 */
+/***/ (function(module, exports) {
+
+module.exports = __WEBPACK_EXTERNAL_MODULE_2__;
+
+/***/ })
+/******/ ]);
+});

--- a/test/fixtures/operator-let/index.js
+++ b/test/fixtures/operator-let/index.js
@@ -1,0 +1,1 @@
+import letProto from 'rxjs/operator/let';

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -26,7 +26,10 @@ describe('webpack-rxjs-externals', () => {
               libraryTarget: 'umd',
               library: 'rxjsTest'
             },
-            externals: webpackRxjsExternals()
+            externals: webpackRxjsExternals(),
+            resolve: {
+              alias: webpackRxjsExternals.alias()
+            }
           };
 
           const expectedOutput = fs.readFileSync(path.join(__dirname, fixturesDir, fixture, 'expected', 'index.js')).toString();


### PR DESCRIPTION
The operator function in `rxjs/operator/let` is exported with the name `letProto`, but the name used for the function on the prototype is `let`. This causes problems with imports that are mapped to `Rx.Observable.prototype`, as `letProto` won't exist.

This PR uses a mechanism that I've used in the Webpack configuration for another project. Specifically, it uses an alias to require a file that, in turn, requires `rxjs/Observable` and re-exports the prototype's `let` as `letProto`.

Whether or not there's a better way of solving this problem, I don't know, but this has worked for me and I'd like to discard my Webpack config and use this package - as it's more convenient.